### PR TITLE
Prevent duplicate search result

### DIFF
--- a/src/cabalParser.js
+++ b/src/cabalParser.js
@@ -148,7 +148,7 @@ exports.CabalFileWatcher = function CabalFileWatcher() {
       returnedDependencies = `${returnedDependencies} ${me.dependencies}`;
     }
 
-    return returnedDependencies;
+    return _.chain(returnedDependencies.split(" ")).unique().join(" ").value();
   }
 
   setConfigSettings();


### PR DESCRIPTION
Was happening due to duplicate modules passed to Hoogle service.